### PR TITLE
Fix post-login redirection

### DIFF
--- a/src/emc-metalnx-shared/src/main/java/com/emc/metalnx/controller/LoginController.java
+++ b/src/emc-metalnx-shared/src/main/java/com/emc/metalnx/controller/LoginController.java
@@ -134,9 +134,16 @@ public class LoginController {
 	@RequestMapping(value = "/exception", method = RequestMethod.GET)
 	public ModelAndView loginErrorHandler(final Exception e) {
 		logger.info("LoginContoller loginErrorHandler()");
-		ModelAndView model = new ModelAndView("login/index");
-		model.addObject("usernameOrPasswordInvalid", true);
-		addAuthTypesAndDefaultAuthToModel(model);
+		ModelAndView model = null;
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+		if (auth instanceof UsernamePasswordAuthenticationToken) {
+			model = new ModelAndView("redirect:/login/");
+		} else {
+			model = new ModelAndView("login/index");
+			model.addObject("usernameOrPasswordInvalid", true);
+			addAuthTypesAndDefaultAuthToModel(model);
+		}
 
 		return model;
 	}


### PR DESCRIPTION
*Behavior:*

If the client starts their session at `/login` and has a failed login attempt, they will be redirected to `/login/exception`. Then after successful authentication, the client will remain at `/login/exception`. This is because there's no saved URL in the session.

*Expected result:*

After successful authentication, the user will be redirected to the saved URL or homepage.

*Solution:*

The main login page at `/login` has logic to check if the user is authenticated and redirect if necessary. Rather than reproduce it in `/login/exception`, just redirect the user back to `/login`.